### PR TITLE
Removed finding severity components that are interfering with pages

### DIFF
--- a/ptportal/templates/ptportal/data-exfil.html
+++ b/ptportal/templates/ptportal/data-exfil.html
@@ -35,7 +35,6 @@ DM22-1011
 <nav aria-label="breadcrumb">
 	<ol class="breadcrumb">
 	 <li class="breadcrumb-item"><a href="{% url 'index' %}">Dashboard</a></li>
-	 <li class="breadcrumb-item"><a href="{% url 'finding_severity' finding.severity %}">{{ finding.severity }}</a></li>
 	 <li class="breadcrumb-item active"><a href="{% url 'finding_detail' finding.slug %}"> {{ finding }} Details</a></li>
 	 <li class="breadcrumb-item active">Exfiltrated Data</li>
 	</ol>

--- a/ptportal/templates/ptportal/finding/finding_detail.html
+++ b/ptportal/templates/ptportal/finding/finding_detail.html
@@ -58,9 +58,6 @@ DM22-1011
       <li class="breadcrumb-item"><a href="{% url 'report' %}">Report</a></li>
     {% else %}
       <li class="breadcrumb-item"><a href="{% url 'index' %}">Dashboard</a></li>
-      {% if previous_url|stringformat:"s" == object.severity|stringformat:"s" %}
-        <li class="breadcrumb-item">	<a href="{% url 'finding_severity' object.severity %}">{{object.severity}}</a></li>
-      {% endif %}
     {% endif %}
 	 <li class="breadcrumb-item active">{{object.uploaded_finding_name}} Details</li>
 

--- a/ptportal/templates/ptportal/finding/finding_detail2.html
+++ b/ptportal/templates/ptportal/finding/finding_detail2.html
@@ -58,9 +58,6 @@ DM22-1011
       <li class="breadcrumb-item"><a href="{% url 'report' %}">Report</a></li>
     {% else %}
       <li class="breadcrumb-item"><a href="{% url 'index' %}">Dashboard</a></li>
-      {% if previous_url|stringformat:"s" == object.severity|stringformat:"s" %}
-        <li class="breadcrumb-item">	<a href="{% url 'finding_severity' object.severity %}">{{object.severity}}</a></li>
-      {% endif %}
     {% endif %}
 	 <li class="breadcrumb-item active">{{object.uploaded_finding_name}} Details</li>
 

--- a/ptportal/templates/ptportal/finding/image_upload.html
+++ b/ptportal/templates/ptportal/finding/image_upload.html
@@ -45,7 +45,6 @@ DM22-1011
 <nav aria-label="breadcrumb">
 	<ol class="breadcrumb">
 	 <li class="breadcrumb-item"><a href="{% url 'index' %}">Dashboard</a></li>
-	 <li class="breadcrumb-item"><a href="{% url 'finding_severity' finding.severity %}">{{finding.severity}}</a></li>
 	 <li class="breadcrumb-item"><a href="{% url 'finding_detail' finding.slug %}">{{finding.uploaded_finding_name}} Details</a></li>
    <li class="breadcrumb-item active">{{finding.uploaded_finding_name}} Edit</li>
 	</ol>

--- a/ptportal/templates/ptportal/index.html
+++ b/ptportal/templates/ptportal/index.html
@@ -27,7 +27,7 @@ DM22-1011
 				<h2 class="text-right pt-3 pr-3 text-2xl align-top">{{ total_critical}} Critical</h2>
 			</header>
 			<div class="p-4 h-2/6">
-				<sds-link href="{% url 'finding_severity' 'critical' %}" variant="info" v-bind:cta="true">View Details</sds-link>
+				<sds-link href="" variant="info" v-bind:cta="true">View Details</sds-link>
 			</div>
 		</div>
 		<div class="block bg-white dark:bg-gray-800 dark:border-gray-700 border">
@@ -36,7 +36,7 @@ DM22-1011
 				<h2 class="text-right pt-3 pr-3 text-2xl align-top">{{ total_high}} High</h2>
 			</header>
 			<div class="p-4 h-2/6">
-				<sds-link href="{% url 'finding_severity' 'high' %}" variant="info" v-bind:cta="true">View Details</sds-link>
+				<sds-link href="" variant="info" v-bind:cta="true">View Details</sds-link>
 			</div>
 		</div>
 		<div class="block bg-white dark:bg-gray-800 dark:border-gray-700 border">
@@ -45,7 +45,7 @@ DM22-1011
 				<h2 class="text-right pt-3 pr-3 text-2xl align-top">{{ total_medium}} Medium</h2>
 			</header>
 			<div class="p-4 h-2/6">
-				<sds-link href="{% url 'finding_severity' 'medium' %}" variant="info" v-bind:cta="true">View Details</sds-link>
+				<sds-link href="" variant="info" v-bind:cta="true">View Details</sds-link>
 			</div>
 		</div>
 	</div>

--- a/ptportal/templates/ptportal/ransomware.html
+++ b/ptportal/templates/ptportal/ransomware.html
@@ -35,7 +35,6 @@ DM22-1011
 <nav aria-label="breadcrumb">
 	<ol class="breadcrumb">
 	 <li class="breadcrumb-item"><a href="{% url 'index' %}">Dashboard</a></li>
-	 <li class="breadcrumb-item"><a href="{% url 'finding_severity' finding.severity %}">{{ finding.severity }}</a></li>
 	 <li class="breadcrumb-item active"><a href="{% url 'finding_detail' finding.slug %}"> {{ finding }} Details</a></li>
 	 <li class="breadcrumb-item active">Ransomware Data</li>
 	</ol>

--- a/ptportal/urls.py
+++ b/ptportal/urls.py
@@ -204,11 +204,6 @@ urlpatterns += [
         views.UploadedFindingDelete.as_view(),
         name='finding_delete',
     ),
-    re_path(
-        '(?P<severity>\w+)/',
-        views.UploadedFindingSeverityListView.as_view(),
-        name='finding_severity',
-    ),
     path(
         'ajax/ajax-get-payloads/',
         views.ajax_get_payloads,

--- a/ptportal/views/findings/findings.py
+++ b/ptportal/views/findings/findings.py
@@ -122,37 +122,6 @@ def ajax_get_payloads(request):
     return JsonResponse(data=data)
 
 
-class UploadedFindingSeverityDisplay(generic.ListView):
-    model = Payload
-    template_name = 'ptportal/finding/finding_severity_list.html'
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['paths'] = Payload.objects.all()
-        return context
-
-
-class UploadedFindingSeverityListView(View):
-    def get(self, request, *args, **kwargs):
-        view = UploadedFindingSeverityDisplay.as_view()
-        return view(request, *args, **kwargs)
-
-    def post(self, request, *args, **kwargs):
-        postData = json.loads(request.POST['data'])
-        uploadedPaths = []
-        for index, data in enumerate(postData):
-            obj = Payload.objects.create(
-                payload_description=data['payload_description'],
-                c2_protocol=data['c2_protocol'],
-                border_protection=data['border_protection'],
-                host_protection=data['host_protection'],
-            )
-            obj.save()
-            uploadedPaths.append(obj)
-
-        return HttpResponse(status=200)
-
-
 class UploadedFindingUpdateView(generic.edit.UpdateView):
     model = UploadedFinding
     form_class = EditUploadedFindingForm


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Miscellaneous finding severity components linked to the Payloads screen were removed to enable other pages to work properly.

## 💭 Motivation and context ##

These components were overriding other views and the overall Payloads screen and finding severity logic will be re-implemented correctly in a separate branch.

## 🧪 Testing ##

Tested on a Linux VM image that is configured for hosting the Reporting Engine during engagements.