### PR TITLE
Implement Payload Parser Function for Payloads Screen

### DIFF
--- a/ptportal/models/phishing.py
+++ b/ptportal/models/phishing.py
@@ -107,13 +107,13 @@ class Payload(abstract_models.TimeStampedModel):
     RESULT_CHOICES = (("B", "Blocked"), ("N", "Not Blocked"))
 
     payload_description = models.CharField(
-        max_length=200,
+        max_length=500,
         verbose_name="Payload Description"
     )
 
     attack_name = models.CharField(
         blank=True,
-        max_length=200,
+        max_length=500,
         verbose_name="MITRE ATT&CK Format"
     )
 
@@ -137,9 +137,28 @@ class Payload(abstract_models.TimeStampedModel):
         default="N",
     )
 
-    locked = models.IntegerField(
+    command = models.CharField(
         blank=True,
-        unique=False
+        null=True,
+        max_length=500,
+    )
+
+    code_type = models.CharField(
+        blank=True,
+        null=True,
+        max_length=500,
+    )
+
+    techniques = models.CharField(
+        blank=True,
+        null=True,
+        max_length=1000,
+    )
+
+    file_types = models.CharField(
+        blank=True,
+        null=True,
+        max_length=500,
     )
     
     order = models.PositiveIntegerField(

--- a/ptportal/templates/ptportal/payloads.html
+++ b/ptportal/templates/ptportal/payloads.html
@@ -81,13 +81,13 @@ DM22-1011
 				<div class="mb-8">
 					<sds-table :fields="fields" :items="items" class="table-prose" v-bind="PayloadTableArgs">
 							<template #cell(payload_description)="{item}">
-								<sds-textarea v-model="item.payload_description" rows="2" placeholder="Payload Description" :maxlength="200"></sds-textarea>
+								<sds-textarea v-model="item.payload_description" rows="2" placeholder="Payload Description" :maxlength="500"></sds-textarea>
 							</template>
 							<template #cell(attack_name)="{item}">
-								<sds-textarea v-model="item.attack_name" rows="2" placeholder="MITRE ATT&CK Format" :disabled="Boolean(item.locked)"></sds-textarea>
+								<sds-textarea v-model="item.attack_name" rows="2" placeholder="MITRE ATT&CK Format" :disabled=true :maxlength="500"></sds-textarea>
 							</template>
 							<template #cell(c2_protocol)="{item}">
-								<sds-input v-model="item.c2_protocol" placeholder="Protocol"></sds-input>
+								<sds-input v-model="item.c2_protocol" placeholder="Protocol" :maxlength="10"></sds-input>
 							</template>
 							<template #cell(host_protection)="{item}">
 								<div class="right-block">
@@ -111,54 +111,6 @@ DM22-1011
 									<p>Not Blocked</p>
 								</div>
 							</template>
-
-								<template #cell(lock)="{item}">
-	                <div v-if="item.locked">
-	                	<sds-floating-ui
-							        popper-class="absolute bg-black text-white text-xs shadow rounded-lg text-center w-56"
-							        placement="top"
-							        arrow-class="absolute bg-black w-2 h-2 rotate-45"
-							        placement-top-arrow-class="-bottom-1"
-							        placement-right-arrow-class="-left-1"
-							        placement-bottom-arrow-class="-top-1"
-							        placement-left-arrow-class="-right-1"
-							        :will-open="willOpen"
-							        :will-close="willClose"
-							      >
-							      <template #trigger="{ open, close }">
-	                  	<sds-button variant="primary" type="button" @click="item.locked = Boolean(0)" @mouseover="open" @mouseout="close">Unlock</sds-button>
-	                	</template>
-	                	<template #default>
-					          <div class="p-2">
-					            <p>Unlock to customize the MITRE ATT&CK Format. Keep in mind the MITRE ATT&CK Format will NOT automatically generate for any payload that is unlocked.</p>
-					          </div>
-					        	</template>
-					      		</sds-floating-ui>
-	                </div>
-
-	                <div v-if="!item.locked">
-	                	<sds-floating-ui
-							        popper-class="absolute bg-black text-white text-xs shadow rounded-lg text-center w-56"
-							        placement="top"
-							        arrow-class="absolute bg-black w-2 h-2 rotate-45"
-							        placement-top-arrow-class="-bottom-1"
-							        placement-right-arrow-class="-left-1"
-							        placement-bottom-arrow-class="-top-1"
-							        placement-left-arrow-class="-right-1"
-							        :will-open="willOpen"
-							        :will-close="willClose"
-							      >
-							      <template #trigger="{ open, close }">
-	                  	<sds-button variant="primary" type="button" @click="item.locked = Boolean(1)" @mouseover="open" @mouseout="close">Lock</sds-button>
-	                	</template>
-	                	<template #default>
-					          <div class="p-2">
-					            <p>Lock to automatically generate the MITRE ATT&CK Format when the page is saved. Keep in mind any pre-existing ATT&CK contents will be overwritten by a new format based on the Payload Description for any payload that is locked.</p>
-					          </div>
-					        	</template>
-					      		</sds-floating-ui>
-	                </div>
-	              </template>
 
 							<template #cell(delete)="{item}">
 								<sds-button type="button" @click="deletePayload(item)" ><img class="w-8 h-8" src="/static/icons/trash-solid.svg"></sds-button>
@@ -208,9 +160,6 @@ function pageData() {
 						label: "Border Protection",
 					},
 					{
-						key: "lock",
-					},
-					{
 						key: "delete",
 					}
 				],
@@ -239,7 +188,7 @@ function pageData() {
       border = true
     {% endif %}
 
-		data.PayloadTableArgs.items.push({id: "{{payload.order}}", payload_description: "{{payload.payload_description|escapejs}}", attack_name: "{{payload.attack_name|escapejs}}", c2_protocol: "{{payload.c2_protocol|escapejs}}", host_protection: host, border_protection: border, locked: parseInt("{{payload.locked}}")})
+		data.PayloadTableArgs.items.push({id: "{{payload.order}}", payload_description: "{{payload.payload_description|escapejs}}", attack_name: "{{payload.attack_name|escapejs}}", c2_protocol: "{{payload.c2_protocol|escapejs}}", host_protection: host, border_protection: border})
 
 	{% endfor %}
 
@@ -260,7 +209,6 @@ function pageMethods() {
 				}
 			})
 
-			// if description field is empty show pop up notification
 			if (this.notify) {
 				this.displayNotification({title: "Error Saving Data", text: "One or more Payloads are missing a description. Please enter a description for each payload before saving.", variant: "danger"})
 				this.notify = false
@@ -288,7 +236,7 @@ function pageMethods() {
 		},
 
 		addPayload: async function () {
-			this.PayloadTableArgs.items.push({id: this.PayloadTableArgs.items.length + 1, payload_description: "", attack_name: "", c2_protocol: "", host_protection: true, border_protection: false, locked: 1})
+			this.PayloadTableArgs.items.push({id: this.PayloadTableArgs.items.length + 1, payload_description: "", attack_name: "", c2_protocol: "", host_protection: true, border_protection: false})
 		},
 
 		deletePayload: function(item) {
@@ -332,14 +280,7 @@ function pageMethods() {
 					b = true
 				}
 
-				if (values[1] == "") {
-					lock = true
-				}
-				else {
-					lock = false
-				}
-
-				this.PayloadTableArgs.items.push({id: this.PayloadTableArgs.items.length + 1, payload_description: values[0], attack_name: values[1], c2_protocol: values[2], host_protection: h, border_protection: b, locked: lock})
+				this.PayloadTableArgs.items.push({id: this.PayloadTableArgs.items.length + 1, payload_description: values[0], attack_name: values[1], c2_protocol: values[2], host_protection: h, border_protection: b})
 			}
 
 			this.displayNotification({'title': 'Payloads Added', text: 'Payloads have been added to the table below. Saving this screen will populate the MITRE ATT&CK formats accordingly.', variant:"info"})

--- a/ptportal/templates/ptportal/payloads.html
+++ b/ptportal/templates/ptportal/payloads.html
@@ -48,10 +48,6 @@ DM22-1011
 {% endblock %}
 
 {% block content %}
-<div class="header">
-  <h2> Payload Testing Results</h2>
-</div>
-
 <div class="col-span-5">
 	{% csrf_token %}
 
@@ -85,10 +81,10 @@ DM22-1011
 				<div class="mb-8">
 					<sds-table :fields="fields" :items="items" class="table-prose" v-bind="PayloadTableArgs">
 							<template #cell(payload_description)="{item}">
-								<sds-textarea v-model="item.payload_description" rows="1" placeholder="Payload Description" :maxlength="200"></sds-textarea>
+								<sds-textarea v-model="item.payload_description" rows="2" placeholder="Payload Description" :maxlength="200"></sds-textarea>
 							</template>
 							<template #cell(attack_name)="{item}">
-								<sds-textarea v-model="item.attack_name" rows="1" placeholder="MITRE ATT&CK Format" :disabled="Boolean(item.locked)"></sds-textarea>
+								<sds-textarea v-model="item.attack_name" rows="2" placeholder="MITRE ATT&CK Format" :disabled="Boolean(item.locked)"></sds-textarea>
 							</template>
 							<template #cell(c2_protocol)="{item}">
 								<sds-input v-model="item.c2_protocol" placeholder="Protocol"></sds-input>
@@ -184,9 +180,7 @@ function pageData() {
 		fileList: [],
 		formData: [],
 		overwriteWarning: false,
-		//to display pop up notification
 		notify: null,
-		// payload table columns
 		PayloadTableArgs: {
 				fields: [
 					{
@@ -245,11 +239,15 @@ function pageData() {
       border = true
     {% endif %}
 
-		data.PayloadTableArgs.items.push({id: "{{payload.order}}", payload_description: "{{payload.payload_description}}", attack_name: "{{payload.attack_name}}", c2_protocol: "{{payload.c2_protocol}}", host_protection: host, border_protection: border, locked: parseInt("{{payload.locked}}")})
+		data.PayloadTableArgs.items.push({id: "{{payload.order}}", payload_description: "{{payload.payload_description|escapejs}}", attack_name: "{{payload.attack_name|escapejs}}", c2_protocol: "{{payload.c2_protocol|escapejs}}", host_protection: host, border_protection: border, locked: parseInt("{{payload.locked}}")})
 
 	{% endfor %}
 
 	return data
+}
+
+function pageCreated() {
+	this.baseData.layoutArgs.pageTitle = "Payload Testing Results"
 }
 
 function pageMethods() {
@@ -277,7 +275,8 @@ function pageMethods() {
 					headers: {"X-CSRFToken": document.getElementsByName("csrfmiddlewaretoken")[0].value}
 				}).then(response => {
 				if(response.ok) {
-					this.displayNotification({title: "Payloads Saved", text: "Payload data saved successfully. Refresh page to see updated MITRE ATT&CK Formats.", variant: "success"})
+					this.displayNotification({title: "Payloads Saved", text: "Payload data saved successfully. Please wait while the page refreshes...", variant: "success"})
+					setTimeout(() => {this.redirectLink("{% url 'payloads' %}")}, 2000)
 				}
 				else {
 					this.displayNotification({title: "Error saving data", text: 'Bad response received from server. Check for errors in forms and try again.', variant: "danger"})
@@ -301,7 +300,6 @@ function pageMethods() {
 		},
 
 		parseData: async function(overwrite) {
-			//May change this to disable button instead of a check.
 			if (document.getElementsByName('payloadUpload')[0].files.length == 0) {
 				return
 			}
@@ -309,8 +307,6 @@ function pageMethods() {
 			const fileName = document.getElementsByName('payloadUpload')[0].files[0]
 			let payloadString = null
 			await fileName.text().then(text => {payloadString = text})
-
-			// add error handling
 
 			if (overwrite) {
 				this.PayloadTableArgs.items = []
@@ -345,6 +341,8 @@ function pageMethods() {
 
 				this.PayloadTableArgs.items.push({id: this.PayloadTableArgs.items.length + 1, payload_description: values[0], attack_name: values[1], c2_protocol: values[2], host_protection: h, border_protection: b, locked: lock})
 			}
+
+			this.displayNotification({'title': 'Payloads Added', text: 'Payloads have been added to the table below. Saving this screen will populate the MITRE ATT&CK formats accordingly.', variant:"info"})
 		}
     }
 

--- a/ptportal/views/payload_mapping/lib/data/assessment-tool-map.json
+++ b/ptportal/views/payload_mapping/lib/data/assessment-tool-map.json
@@ -1,257 +1,305 @@
 {
-  "Last Updated": "5/20/2022",
+  "Last Updated": "2/2/2023",
+  "revision": 5,
+  "tools": {
+    "AtomPePacker": {
+      "techniques": [1106, 1027.002],
+      "aliases": []
+    },
+    "BananaPhone": {
+      "techniques": [1106],
+      "aliases": ["banana", "phone"]
+    },
+    "Bankai": {
+      "techniques": [1106, 1027],
+      "aliases": []
+    },
+    "BokuLoader": {
+      "techniques": [1106, 1620, 1562.001, 1562.006],
+      "aliases": ["boku"]
+    },
+    "AceLdr": {
+      "techniques": [1106],
+      "aliases": ["aceldr"]
+    },
+    "Freeze": {
+      "techniques": [1106, 1620, 1562.001, 1562.006],
+      "aliases": ["freeze"]
+    },
+    "Mangle": {
+      "techniques": [1027.001, 1027.008],
+      "aliases": ["mangle"]
+    },
+    "NinjaUUID": {
+      "techniques": [1106],
+      "aliases": ["ninja"]
+    },
+    "CactusTorch": {
+      "techniques": [1059.005, 1055],
+      "aliases": ["cactus", "cactus torch", "cac"]
+    },
+    "Demiguise": {
+      "techniques": [1027.006, 1027],
+      "aliases": ["demi"]
+    },
+    "Evil Clippy": {
+      "techniques": [1564.007],
+      "aliases": ["EvilClippy", "Evil Clipped", "Clipped", "EvilClipped", "VBA Stomped", "Stomped"]
+    },
+     "Follina": {
+      "techniques": [1564.003, 1059.003, 1106, 1140, 1036, 1059.001, 1203, 1218],
+      "aliases": []
+    },
+    "FrostByte": {
+      "techniques": [1027, 1218],
+      "aliases": ["frost byte", "frost"]
+    },
+    "MacroMe": {
+      "techniques": [1059.005, 1027],
+      "aliases": []
+    },
+    "Inflate.py": {
+      "techniques": [1027.001],
+      "aliases": ["inflate", "inflated"]
+    },
+    "Inceptor": {
+      "techniques": [1027, 1027.002, 1106, 1562.001],
+      "aliases": []
+    },
+    "Inno-Shellcode": {
+      "techniques": [1216],
+      "aliases": ["inno", "innosetup", "inno setup"]
+    },
+    "Ivy": {
+      "techniques": [1055.003, 1059.005, 1620, 1027, 1055.012],
+      "aliases": []
+    },
+    "Macro": {
+      "techniques": [1059.005],
+      "aliases": []
+    },
+    "Mochi": {
+      "techniques": [1106, 1055, 1027],
+      "aliases": []
+    },
+    "NimCrypt": {
+      "techniques": [1027],
+      "aliases": []
+    },
+    "NimPackT": {
+      "techniques": [1106, 1027.002],
+      "aliases": ["NimPack", "nim pack"]
+    },
+    "NimGetSyscallStub": {
+      "techniques": [1106],
+      "aliases": ["nim", "Nimget"]
+    },
+    "Object Link Embedded": {
+      "techniques": [1559.002],
+      "aliases": ["ole"]
+    },
+    "ScareCrow": {
+      "techniques": [1574.002, 1106, 1027],
+      "aliases": ["scare", "scary", "crow"]
+    },
+    "SharpShooter": {
+      "techniques": [1027],
+      "aliases": ["sharp", "shooter"]
+    },
+    "SHHHLoader": {
+      "techniques": [1055, 1055.012, 1055.004, 1106, 1497],
+      "aliases": ["shloader", "shhloader", "shhhhloader"]
+    },
+    "TikiTorch": {
+      "techniques": [1059.005, 1055.012],
+      "aliases": ["tiki", "tiki torch"]
+    },
+    "RegAsm": {
+      "techniques": [1218.009],
+      "aliases": []
+    },
+    "Uru": {
+      "techniques": [1027, 1106],
+      "aliases": []
+    },
+    "VelvetSweatShop": {
+      "techniques": [1027],
+      "aliases": ["velvet", "velvet sweat shop"]
+    }
+  },
+  "obfuscations": {
+    "Arsenal": {
+      "techniques": [1027],
+      "aliases": []
+    },
+    "Password": {
+      "techniques": [1027],
+      "aliases": ["pass", "pw", "protected", "secure", "encrypt", "encrypted"]
+    },
+    "Code-Signing": {
+      "techniques": [1553.002],
+      "aliases": ["signing", "signed"]
+    },
+    "Donut": {
+      "techniques": [1027],
+      "aliases": ["nut"]
+    },
+    "Morph": {
+      "techniques": [1027],
+      "aliases": ["morphhta"]
+    },
+    "MSBuild": {
+      "techniques": [1127.001],
+      "aliases": []
+    },
+    "PEZor": {
+      "techniques": [1027.005, 1106],
+      "aliases": []
+    },
+    "CertUtil": {
+      "techniques": [1140, 1553.004],
+      "aliases": []
+    },
+    "Elusive Mice": {
+      "techniques": [1106, 1055.001, 1562],
+      "aliases": ["elusivemice"]
+    },
+    "NTQueAPCThread": {
+      "techniques": [1106],
+      "aliases": []
+    },
+    "System Call": {
+      "techniques": [1106],
+      "aliases": ["system calls","syscall", "syscalls", "unhook", "unhooked", "unhooking"]
+    },
+    "Sandbox": {
+      "techniques": [1497.001],
+      "aliases": ["sandboxing"]
+    },
+    "AMSI Bypass": {
+      "techniques": [1562.001],
+      "aliases": ["amsi"]
+    },
+    "HTML Smuggling": {
+      "techniques": [1027.006],
+      "aliases": ["smuggling", "smuggle"]
+    },
+    "WeirdHTA": {
+      "techniques": [1027],
+      "aliases": ["weird"]
+    },
+    "xeca": {
+      "techniques": [1027],
+      "aliases": []
+    },
+    "Inceptor": {
+      "techniques": [],
+      "aliases": []
+    },
+    "FuckThatPacker": {
+      "techniques": [1027.002, 1106],
+      "aliases": ["ftp", "Fthatpacker"]
+    }
+  },
+  "filetypes": {
+    "EXE": {
+      "techniques": [1204.002],
+      "aliases": ["executable"]
+    },
+     "PSH": {
+      "techniques": [1204.002, 1059.001],
+      "aliases": ["powershell", "ps1"]
+    },
+    "XLSX": {
+      "techniques": [1204.002, 1059.005],
+      "aliases": ["xlsm", "excel", "xls"]
+    },
+    "VBA": {
+      "techniques": [1204.002, 1059.005],
+      "aliases": ["visual", "visual basic", "visual basic application"]
+    },
+    "VB": {
+      "techniques": [1204.002],
+      "aliases": ["vbscript", "vbs"]
+    },
+    "DLL": {
+      "techniques": [1204.002],
+      "aliases": ["dynamic link", "dynamic link library"]
+    },
+    "JS": {
+      "techniques": [1059.007],
+      "aliases": ["javascript"]
+    },
+    "PIF": {
+      "techniques": [1204.002],
+      "aliases": []
+    },
+    "HTA": {
+      "techniques": [1204.002],
+      "aliases": ["html application"]
+    },
+    "DOC": {
+      "techniques": [1204.002, 1059.005],
+      "aliases": ["docx", "docm", "word", "office document"]
+    },
+    "IMG": {
+      "techniques": [1204.002, 1553.005],
+      "aliases": []
+    },
+    "ISO": {
+      "techniques": [1204.002, 1553.005],
+      "aliases": []
+    },
+    "CHM": {
+      "techniques": [1218],
+      "aliases": [ "helpfile", "help file"]
+    },
+    "CPL": {
+      "techniques": [],
+      "aliases": ["control panel"]
+    },
+    "HTML": {
+      "techniques": [1204.002, 1218.001],
+      "aliases": ["compiled html"]
+    },
+    "ZIP": {
+      "techniques": [],
+      "aliases": ["zipped"]
+    }
+  },
   "code_types": {
+    "GO": {
+      "techniques": [],
+      "aliases": ["golang"]
+    },
     "C": {
-      "aliases": [],
-      "techniques": []
+      "techniques": [],
+      "aliases": []
     },
     "C#": {
-      "aliases": [
-        "c sharp",
-        "c-sharp"
-      ],
-      "techniques": []
-    },
-    "GO": {
-      "aliases": [
-        "golang"
-      ],
-      "techniques": []
+      "techniques": [],
+      "aliases": ["c sharp", "c-sharp"]
     }
   },
   "commands": {
     "Cobalt Strike": {
-      "aliases": [
-        "cs",
-        "cobalt",
-        "cobaltstrike"
-      ],
-      "default": true,
       "protocols": {
-        "DNS": 1071.004,
         "HTTP": 1071.001,
-        "HTTPS": 1071.001
+        "HTTPS": 1071.001,
+        "DNS": 1071.004
       },
-      "techniques": [
-        1106
-      ]
-    }
-  },
-  "filetypes": {
-    "CHM": {
-      "aliases": [
-        "helpfile",
-        "help file"
-      ],
-      "techniques": [
-        1218
-      ]
-    },
-    "DLL": {
-      "aliases": [
-        "dynamic link",
-        "dynamic link library"
-      ],
-      "techniques": [
-        1204.002
-      ]
-    },
-    "DOC": {
-      "aliases": [
-        "docx",
-        "docm",
-        "word",
-        "office document"
-      ],
-      "techniques": [
-        1204.002,
-        1059.005
-      ]
-    },
-    "EXE": {
-      "aliases": [
-        "executable"
-      ],
-      "techniques": [
-        1204.002
-      ]
-    },
-    "HTA": {
-      "aliases": [
-        "html application"
-      ],
-      "techniques": [
-        1204.002
-      ]
-    },
-    "HTML": {
-      "aliases": [
-        "compiled html"
-      ],
-      "techniques": [
-        1218.001
-      ]
-    },
-    "ISO": {
-      "aliases": [],
-      "techniques": []
-    },
-    "JS": {
-      "aliases": [
-        "javascript"
-      ],
-      "techniques": [
-        1059.007
-      ]
-    },
-    "PSH": {
-      "aliases": [
-        "powershell",
-        "ps1"
-      ],
-      "techniques": []
-    },
-    "VB": {
-      "aliases": [
-        "vbscript",
-        "vbs"
-      ],
-      "techniques": []
-    },
-    "VBA": {
-      "aliases": [
-        "visual",
-        "visual basic",
-        "visual basic application"
-      ],
-      "techniques": []
-    },
-    "XLSX": {
-      "aliases": [
-        "xlsm",
-        "excel",
-        "xls"
-      ],
-      "techniques": [
-        1204.002,
-        1059.005
-      ]
-    }
-  },
-  "obfuscations": {
-    "AMSI Bypass": {
-      "aliases": [
-        "amsi"
-      ],
-      "techniques": [
-        1562.001
-      ]
-    },
-    "CertUtil": {
-      "aliases": [],
-      "techniques": [
-        1140,
-        1553.004
-      ]
-    },
-    "Donut": {
-      "aliases": [
-        "nut"
-      ],
-      "techniques": [
-        1027
-      ]
-    },
-    "HTML Smuggling": {
-      "aliases": [
-        "smuggling",
-        "smuggle"
-      ],
-      "techniques": [
-        1027.006
-      ]
-    },
-    "Inceptor": {
-      "aliases": [],
-      "techniques": []
-    },
-    "MSBuild": {
-      "aliases": [],
-      "techniques": [
-        1127.001
-      ]
-    },
-    "Morph": {
-      "aliases": [
-        "morphhta"
-      ],
-      "techniques": [
-        1027
-      ]
-    },
-    "PEZor": {
-      "aliases": [],
-      "techniques": [
-        1027.005,
-        1106
-      ]
-    },
-    "Password": {
-      "aliases": [
-        "pass",
-        "pw",
-        "protected",
-        "secure",
-        "encrypt",
-        "encrypted"
-      ],
-      "techniques": [
-        1027
-      ]
-    },
-    "Sandbox": {
-      "aliases": [
-        "sandboxing"
-      ],
-      "techniques": [
-        1497.001
-      ]
-    },
-    "System Call": {
-      "aliases": [
-        "system calls",
-        "syscall",
-        "syscalls",
-        "unhook",
-        "unhooked",
-        "unhooking"
-      ],
-      "techniques": [
-        1106
-      ]
-    },
-    "WeirdHTA": {
-      "aliases": [
-        "weird"
-      ],
-      "techniques": [
-        1027
-      ]
-    },
-    "xeca": {
-      "aliases": [],
-      "techniques": [
-        1027
-      ]
+      "techniques": [1106],
+      "default": true,
+      "aliases": ["cs", "cobalt", "cobaltstrike"]
     }
   },
   "security": {
     "Avast Endpoint": {},
     "Bitdefender": {},
-    "CYREN AntiVirus": {},
     "Carbon Black": {},
     "Check Point": {},
-    "Cisco Advanced Malware Protection (AMP)": {},
+    "Cisco Advanced Malware Protection (AMP)" : {},
+    "Cisco Secure Endpoint": {},
     "Cisco Firepower": {},
     "Cisco Stealthwatch": {},
     "Cisco Umbrella": {},
@@ -260,162 +308,23 @@
     "CrowdStrike": {},
     "Cylance Endpoint Security": {},
     "Cynet Next-Gen Antivirus (NGAV)": {},
+    "CYREN AntiVirus": {},
     "ESET-NOD32": {},
     "F-Secure": {},
     "FireEye Endpoint Security": {},
     "Fortinet": {},
     "Kaspersky": {},
     "Malwarebytes": {},
-    "McAfee": {},
     "Microsoft Windows Defender": {},
     "Microsoft Windows Defender ATP": {},
+    "McAfee": {},
     "SentinelOne": {},
     "Sophos Intercept X": {},
     "Sophos Intercept X Advanced with Extended Detection and Response (XDR)": {},
     "Sophos Managed Threat Response (MTR)": {},
     "Symantec Endpoint Security": {},
     "TrendMicro": {},
-    "WebRoot": {}
-  },
-  "tools": {
-    "BananaPhone": {
-      "aliases": [
-        "banana",
-        "phone"
-      ],
-      "techniques": [
-        1106
-      ]
-    },
-    "Bankai": {
-      "aliases": [],
-      "techniques": [
-        1106,
-        1027
-      ]
-    },
-    "CactusTorch": {
-      "aliases": [
-        "cactus",
-        "cactus torch",
-        "cac"
-      ],
-      "techniques": [
-        1059.005,
-        1055
-      ]
-    },
-    "Demiguise": {
-      "aliases": [
-        "demi"
-      ],
-      "techniques": [
-        1027.006,
-        1027
-      ]
-    },
-    "FrostByte": {
-      "aliases": [
-        "frost byte",
-        "frost"
-      ],
-      "techniques": [
-        1027,
-        1218
-      ]
-    },
-    "Ivy": {
-      "aliases": [],
-      "techniques": [
-        1055.003,
-        1059.005,
-        1620,
-        1027,
-        1055.012
-      ]
-    },
-    "Macro": {
-      "aliases": [],
-      "techniques": [
-        1059.005
-      ]
-    },
-    "MacroMe": {
-      "aliases": [],
-      "techniques": [
-        1059.005,
-        1027
-      ]
-    },
-    "NimGetSyscallStub": {
-      "aliases": [
-        "nim"
-      ],
-      "techniques": [
-        1106
-      ]
-    },
-    "NinjaUUID": {
-      "aliases": [
-        "ninja"
-      ],
-      "techniques": [
-        1106
-      ]
-    },
-    "Object Link Embedded": {
-      "aliases": [
-        "ole"
-      ],
-      "techniques": [
-        1559.002
-      ]
-    },
-    "RegAsm": {
-      "aliases": [],
-      "techniques": [
-        1218.009
-      ]
-    },
-    "ScareCrow": {
-      "aliases": [
-        "scare",
-        "scary",
-        "crow"
-      ],
-      "techniques": [
-        1574.002,
-        1106,
-        1027
-      ]
-    },
-    "SharpShooter": {
-      "aliases": [
-        "sharp",
-        "shooter"
-      ],
-      "techniques": [
-        1027
-      ]
-    },
-    "TikiTorch": {
-      "aliases": [
-        "tiki",
-        "tiki torch"
-      ],
-      "techniques": [
-        1059.005,
-        1055.012
-      ]
-    },
-    "VelvetSweatShop": {
-      "aliases": [
-        "velvet",
-        "velvet sweat shop"
-      ],
-      "techniques": [
-        1027
-      ]
-    }
+    "WebRoot": {},
+    "Vipre": {}
   }
 }

--- a/ptportal/views/payloads.py
+++ b/ptportal/views/payloads.py
@@ -30,11 +30,6 @@ class PayloadResults(generic.base.TemplateView):
 
     def post(self, request, *args, **kwargs):
         postData = json.loads(request.body)
-        #diff = Payload.objects.all().count() - len(postData)
-
-        #if diff > 0:
-        #    for i in range(diff):
-        #        Payload.objects.order_by('-order')[0].delete()
 
         payloads = []
 
@@ -102,7 +97,7 @@ class PayloadResults(generic.base.TemplateView):
 
         for deleted in deletedItems:
             deleted.delete()
-            
+
         return HttpResponse(status=200)
 
 

--- a/ptportal/views/payloads.py
+++ b/ptportal/views/payloads.py
@@ -16,7 +16,7 @@
 from django.core.exceptions import ValidationError
 from django.views import generic
 from django.http import HttpResponse
-import json
+import json, re, os
 from ..models import Payload
 
 
@@ -30,13 +30,16 @@ class PayloadResults(generic.base.TemplateView):
 
     def post(self, request, *args, **kwargs):
         postData = json.loads(request.body)
-        diff = Payload.objects.all().count() - len(postData)
+        #diff = Payload.objects.all().count() - len(postData)
 
-        if diff > 0:
-            for i in range(diff):
-                Payload.objects.order_by('-order')[0].delete()
+        #if diff > 0:
+        #    for i in range(diff):
+        #        Payload.objects.order_by('-order')[0].delete()
+
+        payloads = []
 
         for order, data in enumerate(postData):
+
             if (
                 data['payload_description']
                 == data['attack_name']
@@ -55,28 +58,35 @@ class PayloadResults(generic.base.TemplateView):
             else:
                 border = "B"
 
-            obj = Payload.objects.filter(order=order + 1)
+            attack_name = ""
 
-            if obj.exists():
-                try:
-                    obj.update(
-                        payload_description=data['payload_description'],
-                        attack_name=data['attack_name'],
-                        c2_protocol=data['c2_protocol'],
-                        host_protection=host,
-                        border_protection=border,
-                        locked=data['locked']
-                    )
+            if data['locked']:
+                program = Program()
 
-                except (KeyError, ValidationError) as e:
-                    return HttpResponse(status=400, reason=e)
+                payload = {'payload_description': data['payload_description'], 'c2_protocol': data['c2_protocol'], 'filename': ''}
+                program.add_payload(payload)
+                program.parse()
+                attack_name = program.payloads[0].filename
+
+            else:
+                attack_name = data['attack_name']
+
+            if Payload.objects.filter(order=order + 1).exists():
+                obj = Payload.objects.filter(order=order + 1).first()
+                obj.payload_description=data['payload_description']
+                obj.attack_name=attack_name
+                obj.c2_protocol=data['c2_protocol']
+                obj.host_protection=host
+                obj.border_protection=border
+                obj.locked=data['locked']
+                obj.save()
 
             else:
                 try:
-                    Payload.objects.create(
+                    obj = Payload.objects.create(
                         order=order + 1,
                         payload_description=data['payload_description'],
-                        attack_name=data['attack_name'],
+                        attack_name=attack_name,
                         c2_protocol=data['c2_protocol'],
                         host_protection=host,
                         border_protection=border,
@@ -84,5 +94,303 @@ class PayloadResults(generic.base.TemplateView):
                     )
 
                 except (KeyError, ValidationError) as e:
+                    print(e)
                     return HttpResponse(status=400, reason=e)
+            payloads.append(obj)
+
+        deletedItems = set(Payload.objects.all()) - set(payloads)
+
+        for deleted in deletedItems:
+            deleted.delete()
+            
         return HttpResponse(status=200)
+
+
+class PayloadObj(object):
+    def __init__(self, data):
+        self.payload_description = data["payload_description"]
+        self.tool_used = False
+        self.filetype = None
+        self.codetype = None
+        self.techniques = []
+        self.filename = None
+        self.c2_protocol = data["c2_protocol"]
+
+    def concatenation(self):
+        longname = ""
+        longname += self.filetype.upper() + "-"
+
+        if self.codetype:
+            longname += self.codetype + "-"
+
+        for i in range(len(self.techniques)):
+            if i == (len(self.techniques)-1):
+                longname += str(self.techniques[i])
+            else:
+                longname += str(self.techniques[i]) + "-"
+
+        self.filename = longname
+
+
+class Tool(object):
+    def __init__(self, name, attributes):
+        self.name = name
+        self.technique_mapping = {},
+        self.kill = False
+
+        if attributes["techniques"]:
+            self.techniques = attributes["techniques"]
+        else:
+            self.techniques = []
+
+        if attributes["aliases"]:
+            self.aliases = attributes["aliases"]
+        else:
+            self.aliases = []
+
+
+class Obfuscation(object):
+    def __init__(self, name, attributes):
+        self.name = name
+
+        if attributes["techniques"]:
+            self.techniques = attributes["techniques"]
+        else:
+            self.techniques = []
+
+        if attributes["aliases"]:
+            self.aliases = attributes["aliases"]
+        else:
+            self.aliases = []
+
+
+class Filetype(object):
+    def __init__(self, name, attributes):
+        self.name = name
+
+        if attributes["techniques"]:
+            self.techniques = attributes["techniques"]
+        else:
+            self.techniques = []
+
+        if attributes["aliases"]:
+            self.aliases = attributes["aliases"]
+        else:
+            self.aliases = []
+
+
+class Command(object):
+    def __init__(self, name, attributes):
+        self.name = name
+
+        if attributes["protocols"]:
+            self.protocols = attributes["protocols"]
+        else:
+            self.protocols = {}
+
+        if attributes["techniques"]:
+            self.techniques = attributes["techniques"]
+        else:
+            self.techniques = {}
+
+        if attributes["default"]:
+            self.default = attributes["default"]
+        else:
+            self.default = False
+
+        if attributes["aliases"]:
+            self.aliases = attributes["aliases"]
+        else:
+            self.aliases = []
+
+
+class Search(object):
+    """ Searches Objects """
+
+    def __init__(self, parser):
+        """ For Each Payload Search For Every Instance Function """
+        self.parser = parser
+
+    def execute_search_on_normal(self):
+        """ Performs the Search on Unmodified JSON File """
+        for payload in self.parser.payloads:
+            self.init_tool_search(payload)
+            self.init_obfuscation_search(payload)
+            self.init_file_type_search(payload)
+            self.init_command_search(payload)
+            payload.concatenation()
+
+    def init_tool_search(self, payload):
+        """ Search for Every Possible Tool """
+        tool_list = []
+
+        for tool_name, tool_instance in self.parser.tools.items():
+            if not re.search(r'%s\b' %tool_name, payload.payload_description, re.IGNORECASE):
+                if tool_instance.aliases:
+                    for aliase in tool_instance.aliases:
+                        if re.search(r'%s\b' %aliase, payload.payload_description, re.IGNORECASE):
+                            payload.tool_used = True
+                            tool_list.append(tool_instance)
+                            break
+            elif re.search(r'%s\b' %tool_name, payload.payload_description, re.IGNORECASE):
+                payload.tool_used = True
+                tool_list.append(tool_instance)
+
+        """ Search For Tools within Tools e.g (Macro -> MacroMe) """
+        if len(tool_list) >= 2:
+            updated_tool_list = []
+            for tool in tool_list:
+                for i in range(len(tool_list)):
+                    if tool.name == tool_list[i].name:
+                        continue
+                    elif re.search(tool.name, tool_list[i].name, re.IGNORECASE):
+                        tool.kill = True
+
+            for tool in tool_list:
+                if tool.kill:
+                    continue
+                else:
+                    updated_tool_list.append(tool)
+
+                """ Reset Value """
+                tool.kill = False
+                tool_list = updated_tool_list
+
+        for tool in tool_list:
+            for technique in tool.techniques:
+                if technique not in payload.techniques:
+                    payload.techniques.append(technique)
+
+    def init_obfuscation_search(self, payload):
+        """ Searches for Obfuscation Instances """
+        for obfuscation_name, obfuscation_instance in self.parser.obfuscations.items():
+            if not re.search(r'%s\b' %obfuscation_name, payload.payload_description, re.IGNORECASE):
+                if obfuscation_instance.aliases:
+                    for aliase in obfuscation_instance.aliases:
+                        if re.search(r'%s\b' %aliase, payload.payload_description, re.IGNORECASE):
+                            for technique in obfuscation_instance.techniques:
+                                if technique not in payload.techniques:
+                                    payload.techniques.append(technique)
+                            break
+
+            elif re.search(r'%s\b' %obfuscation_name, payload.payload_description, re.IGNORECASE):
+                payload.tool_used = True
+                for technique in obfuscation_instance.techniques:
+                    if technique not in payload.techniques:
+                        payload.techniques.append(technique)
+
+    def init_file_type_search(self, payload):
+        """ Searches for Filetypes """
+        found = False
+        types = []
+
+        for filetype_name, filetype_instance in self.parser.filetypes.items():
+            if not re.search(r'%s\b' % filetype_name, payload.payload_description, re.IGNORECASE):
+                if filetype_instance.aliases:
+                    for aliase in filetype_instance.aliases:
+                        if re.search(r'%s\b' % aliase, payload.payload_description, re.IGNORECASE):
+                            if filetype_name not in types:
+                                types.append(filetype_instance)
+                                found = True
+
+            elif re.search(r'%s\b' % filetype_name, payload.payload_description, re.IGNORECASE):
+                if filetype_name not in types:
+                    types.append(filetype_instance)
+                    found = True
+
+        """ Add Techniques """
+        if found:
+            for t in types:
+                for technique in t.techniques:
+                    if technique not in payload.techniques:
+                        payload.techniques.append(technique)
+
+        if not found:
+            payload.filetype = "Unknown"
+        else:
+            for i in range(len(types)):
+                if payload.filetype is None:
+                    payload.filetype = ""
+                if i == (len(types) - 1):
+                    payload.filetype += str(types[i].name)
+                else:
+                    payload.filetype += str(types[i].name) + "-"
+
+    def init_command_search(self, payload):
+        """ Searches Command and Control Information Used """
+        command_found = False
+
+        for command_name, command_instance in self.parser.commands.items():
+            if not re.search(r'%s\b' % command_name, payload.payload_description, re.IGNORECASE):
+                if command_instance.aliases:
+                    for aliase in command_instance.aliases:
+                        if re.search(r'%s\b' % aliase, payload.payload_description, re.IGNORECASE):
+                            payload.command = command_instance
+                            command_found = True
+            elif re.search(r'%s\b' % command_name, payload.payload_description, re.IGNORECASE):
+                payload.command = command_instance
+                command_found = True
+
+        """ Sets the Default Command and Control to Defaulted Value """
+        if not command_found:
+            for command_name, command_instance in self.parser.commands.items():
+                if command_instance.default:
+                    payload.command = command_instance
+
+        """ Sets Default Cobalt Techniques if No Tool Used """
+        if not payload.tool_used:
+            for technique in payload.command.techniques:
+                if technique not in payload.techniques:
+                    payload.techniques.append(technique)
+
+        """ Sets the Protocol Ports """
+        for payload_name, technique in payload.command.protocols.items():
+            if re.search(r'%s\b' % payload_name, payload.c2_protocol, re.IGNORECASE):
+                if technique not in payload.techniques:
+                    payload.techniques.append(technique)
+
+
+class Program(object):
+    def __init__(self):
+        self.path = (os.path.dirname(os.path.realpath(__file__)))
+        self.assessment_tool_map = json.loads(open(self.path + "/payload_mapping/lib/data/assessment-tool-map.json", "r").read())
+        self.tools = {}
+        self.filetypes = {}
+        self.obfuscations = {}
+        self.commands = {}
+        self.payloads = []
+
+        self.initialize_tools()
+        self.initialize_obfuscations()
+        self.initialize_commands()
+        self.initialize_filetypes()
+
+    def initialize_tools(self):
+        for tool_name, tool_properties in self.assessment_tool_map["tools"].items():
+            tool_instance = Tool(tool_name, tool_properties)
+            self.tools[tool_instance.name] = tool_instance
+
+    def initialize_filetypes(self):
+        for file_type_name, file_type_properties in self.assessment_tool_map["filetypes"].items():
+            file_type_instance = Filetype(file_type_name, file_type_properties)
+            self.filetypes[file_type_name] = file_type_instance
+
+    def initialize_obfuscations(self):
+        for obfuscation_name, obfuscation_properties in self.assessment_tool_map["obfuscations"].items():
+            obfuscation_instance = Obfuscation(obfuscation_name, obfuscation_properties)
+            self.obfuscations[obfuscation_name] = obfuscation_instance
+
+    def initialize_commands(self):
+        for command_name, command_properties in self.assessment_tool_map["commands"].items():
+            command_instance = Command(command_name, command_properties)
+            self.commands[command_name] = command_instance
+
+    def add_payload(self, data):
+        self.payloads.append(PayloadObj(data))
+
+    def parse(self):
+        Search(self).execute_search_on_normal()
+
+    def print_techniques(self):
+        for payload in self.payloads:
+            payload.concatenation()

--- a/ptportal/views/payloads.py
+++ b/ptportal/views/payloads.py
@@ -54,17 +54,19 @@ class PayloadResults(generic.base.TemplateView):
                 border = "B"
 
             attack_name = ""
+            filetype = ""
+            codetype = ""
+            techniques = ""
 
-            if data['locked']:
-                program = Program()
+            program = Program()
 
-                payload = {'payload_description': data['payload_description'], 'c2_protocol': data['c2_protocol'], 'filename': ''}
-                program.add_payload(payload)
-                program.parse()
-                attack_name = program.payloads[0].filename
-
-            else:
-                attack_name = data['attack_name']
+            payload = {'payload_description': data['payload_description'], 'c2_protocol': data['c2_protocol'], 'filename': ''}
+            program.add_payload(payload)
+            program.parse()
+            filetype = program.payloads[0].filetype
+            codetype = program.payloads[0].codetype
+            techniques = ', '.join(str(i) for i in program.payloads[0].techniques)
+            attack_name = program.payloads[0].filename
 
             if Payload.objects.filter(order=order + 1).exists():
                 obj = Payload.objects.filter(order=order + 1).first()
@@ -73,7 +75,9 @@ class PayloadResults(generic.base.TemplateView):
                 obj.c2_protocol=data['c2_protocol']
                 obj.host_protection=host
                 obj.border_protection=border
-                obj.locked=data['locked']
+                obj.file_types=filetype
+                obj.code_type=codetype
+                obj.techniques=techniques
                 obj.save()
 
             else:
@@ -85,7 +89,9 @@ class PayloadResults(generic.base.TemplateView):
                         c2_protocol=data['c2_protocol'],
                         host_protection=host,
                         border_protection=border,
-                        locked=data['locked']
+                        file_types=filetype,
+                        code_type=codetype,
+                        techniques=techniques
                     )
 
                 except (KeyError, ValidationError) as e:


### PR DESCRIPTION
## 🗣 Description ##

Integrated the pre-existing function for converting payload descriptions to MITRE ATT&CK formats via the Payloads screen in order to automate this process and eliminate the need for assessors to run the parsing tool manually. The option to lock/unlock the MITRE Technique field was removed so that this data can no longer be customized from the front-end in an attempt to preserve the standardization of data across assessments.

## 💭 Motivation and context ##

In order to provide more meaningful context to payload descriptions, @tarrell13 developed a payload parsing tool to automatically derive MITRE ATT&CK techniques from these descriptions based on keywords. This tool was integrated so that artifacts exported from the Reporting Engine will contain these additional attributes by default.

## 🧪 Testing ##

Tested on a Linux VM image that is configured for hosting the Reporting Engine during engagements.
