### PR TITLE
Fix the missing netcat package in the web docker image

### DIFF
--- a/docker/prod/Dockerfile.web
+++ b/docker/prod/Dockerfile.web
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y \
   p7zip-full \
   nano \
   zip \
-  netcat \
+  netcat-openbsd \
   gunicorn
 
 ADD docker/prod/requirements.txt .


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Changes were made to the production Dockerfile for the web image to update the missing `netcat` package to `netcat-openbsd`

## 💭 Motivation and context ##

This change fixes breakage in the current version (tested 1.5.1) of the reporting engine
closes #76 

## 🧪 Testing ##

Tested by standing up an RVA setup with `python3 ptp.py run -r RVA`

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.
