### PR TITLE
Fixed to allow report generation in the absence of risk score info for FAST

### DIFF
--- a/ptportal/views/export.py
+++ b/ptportal/views/export.py
@@ -144,8 +144,11 @@ class Export(generic.base.TemplateView):
         uploaded_list = UploadedFinding.objects.all().order_by('assessment_type', 'severity', 'uploaded_finding_name')
         cis_csc_objects = CIS_CSC.objects.all().order_by('CIS_ID')
 
-        if UploadedFinding.objects.filter(magnitude='').count() > 0 or UploadedFinding.objects.filter(likelihood__isnull=True).count() > 0:
-            context['incomplete_risk_score'] = True
+        if report.report_type == "RVA":
+            if UploadedFinding.objects.filter(magnitude='').count() > 0 or UploadedFinding.objects.filter(likelihood__isnull=True).count() > 0:
+                context['incomplete_risk_score'] = True
+            else:
+                context['incomplete_risk_score'] = False
         else:
             context['incomplete_risk_score'] = False
 


### PR DESCRIPTION
## 🗣 Description ##

Quick fix to allow FAST report generation even if risk score information is not present, since FAST does not require risk score data.

## 💭 Motivation and context ##

The mechanisms in place to prevent artifact generation when risk score information is incomplete was interfering with the ability to generate FAST artifacts that don't require risk score data.

## 🧪 Testing ##

Tested on a Linux VM image that is configured for hosting the Reporting Engine during engagements.